### PR TITLE
feat: Add agent configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,56 @@ npx cap sync
 Now open your `index.tsx` and add the following code to launch NewRelic (don't forget to put proper application tokens):
 
 ``` tsx
-import { NewRelicCapacitorPlugin } from 'newrelic-capacitor-plugin';
+import { NewRelicCapacitorPlugin, NREnums } from 'newrelic-capacitor-plugin';
 import { Capacitor } from '@capacitor/core';
 
     var appToken;
 
-    if(Capacitor.getPlatform() === 'ios') 
+    if(Capacitor.getPlatform() === 'ios') {
         appToken = '<IOS-APP-TOKEN>';
     } else {
         appToken = '<ANDROID-APP-TOKEN>';
     }
 
-NewRelicCapacitorPlugin.start({appKey:appToken})
+    let agentConfig = {
+      //Android Specific
+      // Optional:Enable or disable collection of event data.
+      analyticsEventEnabled: true,
+
+      // Optional:Enable or disable crash reporting.
+      crashReportingEnabled: true,
+
+      // Optional:Enable or disable interaction tracing. Trace instrumentation still occurs, but no traces are harvested. This will disable default and custom interactions.
+      interactionTracingEnabled: true,
+
+      // Optional:Enable or disable reporting successful HTTP requests to the MobileRequest event type.
+      networkRequestEnabled: true,
+
+      // Optional:Enable or disable reporting network and HTTP request errors to the MobileRequestError event type.
+      networkErrorRequestEnabled: true,
+
+      // Optional:Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
+      httpResponseBodyCaptureEnabled: true,
+
+      // Optional:Enable or disable agent logging.
+      loggingEnabled: true,
+
+      // Optional:Specifies the log level. Omit this field for the default log level.
+      // Options include: ERROR (least verbose), WARNING, INFO, VERBOSE, AUDIT (most verbose).
+      logLevel: NREnums.LogLevel.INFO,
+
+      // iOS Specific
+      // Optional:Enable/Disable automatic instrumentation of WebViews
+      webViewInstrumentation: true,
+
+      // Optional:Set a specific collector address for sending data. Omit this field for default address.
+      collectorAddress: "",
+
+      // Optional:Set a specific crash collector address for sending crashes. Omit this field for default address.
+      crashCollectorAddress: ""
+    }
+
+NewRelicCapacitorPlugin.start({appKey:appToken, agentConfiguration:agentConfig})
 
 
 ```
@@ -366,8 +404,8 @@ recordMetric(options: { name: string; category: string; value?: number; countUni
       name: "CapacitorMetricName3",
       category: "CapacitorMetricCategory3",
       value: 30,
-      countUnit: "SECONDS",
-      valueUnit: "OPERATIONS",
+      countUnit: NREnums.MetricUnit.SECONDS,
+      valueUnit: NREnums.MetricUnit.OPERATIONS,
     });
 ```
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,7 +4,7 @@
  */
 
 export interface NewRelicCapacitorPluginPlugin {
-  start(options: { appKey: string }): void;
+  start(options: { appKey: string, agentConfiguration?: object}): void;
   setUserId(options: { userId: string }): void;
   setAttribute(options:{name: string, value: string}): void;
   removeAttribute(options:{name: string}): void;
@@ -45,4 +45,30 @@ export interface NewRelicCapacitorPluginPlugin {
   networkRequestEnabled(options: {enabled: boolean}): void;
   networkErrorRequestEnabled(options: {enabled: boolean}): void;
   httpResponseBodyCaptureEnabled(options: {enabled: boolean}): void;
+}
+
+export namespace NREnums {
+  export enum LogLevel {
+      ERROR = "ERROR",
+      WARNING = "WARNING",
+      INFO = "INFO",
+      VERBOSE = "VERBOSE",
+      AUDIT = "AUDIT",
+  }
+  export enum NetworkFailure {
+      Unknown = 'Unknown',
+      BadURL = 'BadURL',
+      TimedOut = 'TimedOut',
+      CannotConnectToHost = 'CannotConnectToHost',
+      DNSLookupFailed = 'DNSLookupFailed',
+      BadServerResponse = 'BadServerResponse',
+      SecureConnectionFailed = 'SecureConnectionFailed',
+  }
+  export enum MetricUnit  {
+      PERCENT = 'PERCENT',
+      BYTES = 'BYTES',
+      SECONDS = 'SECONDS',
+      BYTES_PER_SECOND = 'BYTES_PER_SECOND',
+      OPERATIONS = 'OPERATIONS',
+  }
 }


### PR DESCRIPTION
Adding configuration options for Capacitor plugin:

- Can now add a new object to start call containing configuration options
- Added new enums that can be imported via `import { NREnums } from @newrelic/newrelic-capacitor-plugin` to avoid magic strings