### PR TITLE
Update agent configuration and add console events flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NewRelic Plugin for ionic Capacitor. This plugin uses native New Relic Android a
 ## Install
 
 ```bash
-npm install newrelic-capacitor-plugin
+npm install @newrelic/newrelic-capacitor-plugin
 npx cap sync
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npx cap sync
 You can start the New Relic agent in the initialization of your app in `main.ts` (Angular or Vue) or `index.tsx` (React). Add the following code to launch NewRelic (don't forget to put proper application tokens):
 
 ``` tsx
-import { NewRelicCapacitorPlugin, NREnums } from 'newrelic-capacitor-plugin';
+import { NewRelicCapacitorPlugin, NREnum, AgentConfiguration } from 'newrelic-capacitor-plugin';
 import { Capacitor } from '@capacitor/core';
 
 var appToken;
@@ -46,7 +46,7 @@ if(Capacitor.getPlatform() === 'ios') {
     appToken = '<ANDROID-APP-TOKEN>';
 }
 
-let agentConfig = {
+let agentConfig : AgentConfiguration = {
   //Android Specific
   // Optional:Enable or disable collection of event data.
   analyticsEventEnabled: true,
@@ -82,6 +82,9 @@ let agentConfig = {
 
   // Optional:Set a specific crash collector address for sending crashes. Omit this field for default address.
   crashCollectorAddress: ""
+
+  // Optional:Enable or disable sending JS console logs to New Relic
+  sendConsoleEvents: true
 }
 
 NewRelicCapacitorPlugin.start({appKey:appToken, agentConfiguration:agentConfig})
@@ -150,6 +153,7 @@ ionic capacitor run ios
 * [`networkRequestEnabled(...)`](#networkrequestenabled)
 * [`networkErrorRequestEnabled(...)`](#networkerrorrequestenabled)
 * [`httpResponseBodyCaptureEnabled(...)`](#httpresponsebodycaptureenabled)
+* [`getAgentConfiguration(...)`](#getagentconfiguration)
 
 
 
@@ -538,6 +542,28 @@ httpResponseBodyCaptureEnabled(options: { enabled: boolean; }) => void
     NewRelicCapacitorPlugin.httpResponseBodyCaptureEnabled({ enabled: true })
 ```
 
+--------------------
+
+
+### getAgentConfiguration(...)
+> Returns the current agent configuration settings. This method allows you to see the current state of the agent configuration.
+```typescript
+getAgentConfiguration(options?: {} | undefined) => Promise<AgentConfiguration>
+```
+
+| Param         | Type            |
+| ------------- | --------------- |
+| **`options`** | <code>{}</code> |
+
+**Returns:** <code>Promise&lt;AgentConfiguration&gt;</code>
+
+#### Usage:
+```ts
+    import { NewRelicCapacitorPlugin, AgentConfiguration} from '@newrelic/newrelic-capacitor-agent';
+
+    let agentConfig : AgentConfiguration = await NewRelicCapacitorPlugin.getAgentConfiguration();
+    let sendConsoleEvents = agentConfig.sendConsoleEvents;
+```
 --------------------
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npx cap sync
 You can start the New Relic agent in the initialization of your app in `main.ts` (Angular or Vue) or `index.tsx` (React). Add the following code to launch NewRelic (don't forget to put proper application tokens):
 
 ``` tsx
-import { NewRelicCapacitorPlugin, NREnum, AgentConfiguration } from 'newrelic-capacitor-plugin';
+import { NewRelicCapacitorPlugin, NREnums, AgentConfiguration } from 'newrelic-capacitor-plugin';
 import { Capacitor } from '@capacitor/core';
 
 var appToken;

--- a/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorPluginPlugin.java
+++ b/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorPluginPlugin.java
@@ -487,7 +487,11 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.AnalyticsEvents);
         }
-        agentConfig.analyticsEventEnabled = toEnable;
+
+        if(agentConfig != null) {
+            agentConfig.analyticsEventEnabled = toEnable;
+        }
+        
         call.resolve();
     }
 
@@ -505,7 +509,11 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.NetworkRequests);
         }
-        agentConfig.networkRequestEnabled = toEnable;
+
+        if(agentConfig != null) {
+            agentConfig.networkRequestEnabled = toEnable;
+        }
+
         call.resolve();
     }
 
@@ -523,7 +531,11 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
         }
-        agentConfig.networkErrorRequestEnabled = toEnable;
+
+        if(agentConfig != null) {
+            agentConfig.networkErrorRequestEnabled = toEnable;
+        }
+
         call.resolve();
     }
 
@@ -541,23 +553,30 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
         }
-        agentConfig.httpResponseBodyCaptureEnabled = toEnable;
+
+        if(agentConfig != null) {
+            agentConfig.httpResponseBodyCaptureEnabled = toEnable;
+        }
+
         call.resolve();
     }
 
     @PluginMethod
     public void getAgentConfiguration(PluginCall call) {
         JSObject ret = new JSObject();
-        ret.put("analyticsEventEnabled", agentConfig.analyticsEventEnabled);
-        ret.put("crashReportingEnabled", agentConfig.crashReportingEnabled);
-        ret.put("interactionTracingEnabled", agentConfig.interactionTracingEnabled);
-        ret.put("networkRequestEnabled", agentConfig.networkRequestEnabled);
-        ret.put("networkErrorRequestEnabled", agentConfig.networkErrorRequestEnabled);
-        ret.put("httpResponseBodyCaptureEnabled", agentConfig.httpResponseBodyCaptureEnabled);
-        ret.put("logLevel", agentConfig.logLevel);
-        ret.put("collectorAddress", agentConfig.collectorAddress);
-        ret.put("crashCollectorAddress", agentConfig.crashCollectorAddress);
-        ret.put("sendConsoleEvents", agentConfig.sendConsoleEvents);
+        // Returns empty object if plugin not loaded
+        if (agentConfig != null) {
+            ret.put("analyticsEventEnabled", agentConfig.analyticsEventEnabled);
+            ret.put("crashReportingEnabled", agentConfig.crashReportingEnabled);
+            ret.put("interactionTracingEnabled", agentConfig.interactionTracingEnabled);
+            ret.put("networkRequestEnabled", agentConfig.networkRequestEnabled);
+            ret.put("networkErrorRequestEnabled", agentConfig.networkErrorRequestEnabled);
+            ret.put("httpResponseBodyCaptureEnabled", agentConfig.httpResponseBodyCaptureEnabled);
+            ret.put("logLevel", agentConfig.logLevel);
+            ret.put("collectorAddress", agentConfig.collectorAddress);
+            ret.put("crashCollectorAddress", agentConfig.crashCollectorAddress);
+            ret.put("sendConsoleEvents", agentConfig.sendConsoleEvents);
+        }
         call.resolve(ret);
     }
 

--- a/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorPluginPlugin.java
+++ b/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorPluginPlugin.java
@@ -34,10 +34,39 @@ import java.util.Map;
 public class NewRelicCapacitorPluginPlugin extends Plugin {
 
     private final NewRelicCapacitorPlugin implementation = new NewRelicCapacitorPlugin();
+    private AgentConfig agentConfig;
+    private static class AgentConfig {
+        boolean analyticsEventEnabled;
+        boolean crashReportingEnabled;
+        boolean interactionTracingEnabled;
+        boolean networkRequestEnabled;
+        boolean networkErrorRequestEnabled;
+        boolean httpResponseBodyCaptureEnabled;
+        boolean loggingEnabled;
+        String logLevel;
+        String collectorAddress;
+        String crashCollectorAddress;
+        boolean sendConsoleEvents;
+
+        public AgentConfig() {
+            this.analyticsEventEnabled = true;
+            this.crashReportingEnabled = true;
+            this.interactionTracingEnabled = true;
+            this.networkRequestEnabled = true;
+            this.networkErrorRequestEnabled = true;
+            this.httpResponseBodyCaptureEnabled = true;
+            this.loggingEnabled = true;
+            this.logLevel = "INFO";
+            this.collectorAddress = "mobile-collector.newrelic.com";
+            this.crashCollectorAddress = "mobile-crash.newrelic.com";
+            this.sendConsoleEvents = true;
+        }
+    }
 
     @Override
     public void load() {
         super.load();
+        agentConfig = new AgentConfig();
     }
 
     @PluginMethod
@@ -59,42 +88,55 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
 
             if(Boolean.FALSE.equals(agentConfiguration.getBool("analyticsEventEnabled"))) {
                 NewRelic.disableFeature(FeatureFlag.AnalyticsEvents);
+                agentConfig.analyticsEventEnabled = false;
             } else {
                 NewRelic.enableFeature(FeatureFlag.AnalyticsEvents);
+                agentConfig.analyticsEventEnabled = true;
             }
 
             if(Boolean.FALSE.equals(agentConfiguration.getBool("crashReportingEnabled"))) {
                 NewRelic.disableFeature(FeatureFlag.CrashReporting);
+                agentConfig.crashReportingEnabled = false;
             } else {
                 NewRelic.enableFeature(FeatureFlag.CrashReporting);
+                agentConfig.crashReportingEnabled = true;
             }
 
             if(Boolean.FALSE.equals(agentConfiguration.getBool("interactionTracingEnabled"))) {
                 NewRelic.disableFeature(FeatureFlag.InteractionTracing);
+                agentConfig.interactionTracingEnabled = false;
             } else {
                 NewRelic.enableFeature(FeatureFlag.InteractionTracing);
+                agentConfig.interactionTracingEnabled = true;
             }
 
             if(Boolean.FALSE.equals(agentConfiguration.getBool("networkRequestEnabled"))) {
                 NewRelic.disableFeature(FeatureFlag.NetworkRequests);
+                agentConfig.networkRequestEnabled = false;
             } else {
                 NewRelic.enableFeature(FeatureFlag.NetworkRequests);
+                agentConfig.networkRequestEnabled = true;
             }
 
             if(Boolean.FALSE.equals(agentConfiguration.getBool("networkErrorRequestEnabled"))) {
                 NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
+                agentConfig.networkErrorRequestEnabled = false;
             } else {
                 NewRelic.enableFeature(FeatureFlag.NetworkErrorRequests);
+                agentConfig.networkErrorRequestEnabled = true;
             }
 
             if(Boolean.FALSE.equals(agentConfiguration.getBool("httpResponseBodyCaptureEnabled"))) {
                 NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
+                agentConfig.httpResponseBodyCaptureEnabled = false;
             } else {
                 NewRelic.enableFeature(FeatureFlag.HttpResponseBodyCapture);
+                agentConfig.httpResponseBodyCaptureEnabled = true;
             }
 
             if(agentConfiguration.getBool("loggingEnabled") != null) {
                 loggingEnabled = Boolean.TRUE.equals(agentConfiguration.getBool("loggingEnabled"));
+                agentConfig.loggingEnabled = loggingEnabled;
             }
 
             if(agentConfiguration.getString("logLevel") != null) {
@@ -106,18 +148,29 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
                 strToLogLevel.put("AUDIT", AgentLog.AUDIT);
 
                 Integer configLogLevel = strToLogLevel.get(agentConfiguration.getString("logLevel"));
-                logLevel = (configLogLevel == null) ? logLevel : configLogLevel;
+                if(configLogLevel != null) {
+                    logLevel = configLogLevel;
+                    agentConfig.logLevel = agentConfiguration.getString("logLevel");
+                }
+
             }
 
             String newCollectorAddress = agentConfiguration.getString("collectorAddress");
             if(newCollectorAddress != null && !newCollectorAddress.isEmpty()) {
                 collectorAddress = newCollectorAddress;
+                agentConfig.collectorAddress = newCollectorAddress;
             }
 
             String newCrashCollectorAddress = agentConfiguration.getString("crashCollectorAddress");
             if(newCrashCollectorAddress != null && !newCrashCollectorAddress.isEmpty()) {
                 crashCollectorAddress = newCrashCollectorAddress;
+                agentConfig.crashCollectorAddress = newCrashCollectorAddress;
             }
+
+            if(agentConfiguration.getBool("sendConsoleEvents") != null) {
+                agentConfig.sendConsoleEvents = agentConfiguration.getBool("sendConsoleEvents");
+            } 
+
         }
 
         // Use default collector addresses if not set
@@ -434,7 +487,7 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.AnalyticsEvents);
         }
-
+        agentConfig.analyticsEventEnabled = toEnable;
         call.resolve();
     }
 
@@ -452,7 +505,7 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.NetworkRequests);
         }
-
+        agentConfig.networkRequestEnabled = toEnable;
         call.resolve();
     }
 
@@ -470,7 +523,7 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
         }
-
+        agentConfig.networkErrorRequestEnabled = toEnable;
         call.resolve();
     }
 
@@ -488,8 +541,24 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
         } else {
             NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
         }
-
+        agentConfig.httpResponseBodyCaptureEnabled = toEnable;
         call.resolve();
+    }
+
+    @PluginMethod
+    public void getAgentConfiguration(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("analyticsEventEnabled", agentConfig.analyticsEventEnabled);
+        ret.put("crashReportingEnabled", agentConfig.crashReportingEnabled);
+        ret.put("interactionTracingEnabled", agentConfig.interactionTracingEnabled);
+        ret.put("networkRequestEnabled", agentConfig.networkRequestEnabled);
+        ret.put("networkErrorRequestEnabled", agentConfig.networkErrorRequestEnabled);
+        ret.put("httpResponseBodyCaptureEnabled", agentConfig.httpResponseBodyCaptureEnabled);
+        ret.put("logLevel", agentConfig.logLevel);
+        ret.put("collectorAddress", agentConfig.collectorAddress);
+        ret.put("crashCollectorAddress", agentConfig.crashCollectorAddress);
+        ret.put("sendConsoleEvents", agentConfig.sendConsoleEvents);
+        call.resolve(ret);
     }
 
 }

--- a/ios/Plugin/NewRelicCapacitorPluginPlugin.m
+++ b/ios/Plugin/NewRelicCapacitorPluginPlugin.m
@@ -30,4 +30,5 @@ CAP_PLUGIN(NewRelicCapacitorPluginPlugin, "NewRelicCapacitorPlugin",
            CAP_PLUGIN_METHOD(networkRequestEnabled, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(networkErrorRequestEnabled, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(httpResponseBodyCaptureEnabled, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(getAgentConfiguration, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
+++ b/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
@@ -13,10 +13,24 @@ import NewRelic
 @objc(NewRelicCapacitorPluginPlugin)
 public class NewRelicCapacitorPluginPlugin: CAPPlugin {
     private let implementation = NewRelicCapacitorPlugin()
+    private var agentConfig = AgentConfiguration()
+    
+    struct AgentConfiguration {
+        var crashReportingEnabled: Bool = true;
+        var interactionTracingEnabled: Bool = true;
+        var networkRequestEnabled: Bool = true;
+        var networkErrorRequestEnabled: Bool = true;
+        var httpResponseBodyCaptureEnabled: Bool = true;
+        var webViewInstrumentation : Bool = true;
+        var loggingEnabled: Bool = true;
+        var logLevel: String = "WARNING"
+        var collectorAddress: String = "mobile-collector.newrelic.com"
+        var crashCollectorAddress: String = "mobile-crash.newrelic.com"
+        var sendConsoleEvents: Bool = true;
+    }
     
     public override func load() {
-                
-  }
+    }
 
     @objc func start(_ call: CAPPluginCall) {
         
@@ -33,26 +47,32 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
             
             if agentConfiguration["crashReportingEnabled"] as? Bool == false {
                 NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_CrashReporting)
+                agentConfig.crashReportingEnabled = false
             }
             
             if agentConfiguration["interactionTracingEnabled"] as? Bool == false {
                 NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_InteractionTracing)
+                agentConfig.interactionTracingEnabled = false
             }
             
             if agentConfiguration["networkRequestEnabled"] as? Bool == false {
                 NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_NetworkRequestEvents)
+                agentConfig.networkRequestEnabled = false
             }
             
             if agentConfiguration["networkErrorRequestEnabled"] as? Bool == false {
                 NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_RequestErrorEvents)
+                agentConfig.networkErrorRequestEnabled = false
             }
             
             if agentConfiguration["httpResponseBodyCaptureEnabled"] as? Bool == false {
                 NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_HttpResponseBodyCapture)
+                agentConfig.httpResponseBodyCaptureEnabled = false
             }
             
             if agentConfiguration["webViewInstrumentation"] as? Bool == false {
                 NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_WebViewInstrumentation)
+                agentConfig.webViewInstrumentation = false;
             }
             
             if agentConfiguration["logLevel"] != nil {
@@ -67,22 +87,45 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
                 
                 if let configLogLevel = agentConfiguration["logLevel"] as? String, strToLogLevel[configLogLevel] != nil {
                     logLevel = strToLogLevel[configLogLevel] ?? logLevel
+                    if (strToLogLevel[configLogLevel] != nil) {
+                        agentConfig.logLevel = configLogLevel
+                    }
+                        
                 }
             }
             
             if agentConfiguration["loggingEnabled"] != nil {
-                logLevel = NRLogLevelNone.rawValue
+                if agentConfiguration["loggingEnabled"] as? Bool == false {
+                    logLevel = NRLogLevelNone.rawValue
+                    agentConfig.loggingEnabled = false
+                }
+                
             }
             
             if agentConfiguration["collectorAddress"] != nil {
                 if let configCollectorAddress = agentConfiguration["collectorAdddress"] as? String, !configCollectorAddress.isEmpty {
                     collectorAddress = configCollectorAddress
+                    agentConfig.collectorAddress = configCollectorAddress
                 }
             }
             
             if agentConfiguration["crashCollectorAddress"] != nil {
                 if let configCrashCollectorAddress = agentConfiguration["crashCollectorAddress"] as? String, !configCrashCollectorAddress.isEmpty {
                     crashCollectorAddress = configCrashCollectorAddress
+                    agentConfig.crashCollectorAddress = configCrashCollectorAddress
+                }
+            }
+
+            if agentConfiguration["crashCollectorAddress"] != nil {
+                if let configCrashCollectorAddress = agentConfiguration["crashCollectorAddress"] as? String, !configCrashCollectorAddress.isEmpty {
+                    crashCollectorAddress = configCrashCollectorAddress
+                    agentConfig.crashCollectorAddress = configCrashCollectorAddress
+                }
+            }
+
+            if agentConfiguration["sendConsoleEvents"] != nil {
+                if let configSendConsoleEvents = agentConfiguration["sendConsoleEvents"] as? Bool {
+                    agentConfig.sendConsoleEvents = configSendConsoleEvents
                 }
             }
         }
@@ -393,6 +436,22 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
             NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_HttpResponseBodyCapture)
         }
         call.resolve()
+    }
+    
+    @objc func getAgentConfiguration(_ call: CAPPluginCall) {
+        call.resolve([
+            "crashReportingEnabled": agentConfig.crashReportingEnabled,
+            "interactionTracingEnabled": agentConfig.interactionTracingEnabled,
+            "networkRequestEnabled": agentConfig.networkRequestEnabled,
+            "networkErrorRequestEnabled": agentConfig.networkErrorRequestEnabled,
+            "httpResponseBodyCaptureEnabled" : agentConfig.httpResponseBodyCaptureEnabled,
+            "webViewInstrumentation": agentConfig.webViewInstrumentation,
+            "loggingEnabled": agentConfig.loggingEnabled,
+            "logLevel": agentConfig.logLevel,
+            "collectorAddress": agentConfig.collectorAddress,
+            "crashCollectorAddress": agentConfig.crashCollectorAddress,
+            "sendConsoleEvents": agentConfig.sendConsoleEvents
+        ])
     }
     
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,7 +4,7 @@
  */
 
 export interface NewRelicCapacitorPluginPlugin {
-  start(options: { appKey: string, agentConfiguration?: object}): void;
+  start(options: { appKey: string, agentConfiguration?: AgentConfiguration}): void;
   setUserId(options: { userId: string }): void;
   setAttribute(options:{name: string, value: string}): void;
   removeAttribute(options:{name: string}): void;
@@ -45,6 +45,22 @@ export interface NewRelicCapacitorPluginPlugin {
   networkRequestEnabled(options: {enabled: boolean}): void;
   networkErrorRequestEnabled(options: {enabled: boolean}): void;
   httpResponseBodyCaptureEnabled(options: {enabled: boolean}): void;
+  getAgentConfiguration(options?: {}) : Promise<AgentConfiguration>;
+}
+
+export interface AgentConfiguration {
+  analyticsEventEnabled?: boolean
+  crashReportingEnabled?: boolean
+  interactionTracingEnabled?: boolean
+  networkRequestEnabled?: boolean
+  networkErrorRequestEnabled?: boolean
+  httpResponseBodyCaptureEnabled?: boolean
+  webViewInstrumentation?: boolean
+  loggingEnabled?: boolean
+  logLevel?: string
+  collectorAddress?: string
+  crashCollectorAddress?: string
+  sendConsoleEvents?: boolean
 }
 
 export namespace NREnums {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,15 @@ console.error = function () {
 };
 
 function sendConsole(consoleType: string, _arguments: any) {
-  const argsStr = JSON.stringify(_arguments, getCircularReplacer());
-  NewRelicCapacitorPlugin.recordCustomEvent({
-    eventType: 'consoleEvents',
-    eventName: 'JSConsole',
-    attributes: { consoleType: consoleType, args: argsStr },
+  NewRelicCapacitorPlugin.getAgentConfiguration().then((agentConfig) => {
+    if (agentConfig.sendConsoleEvents) {
+      const argsStr = JSON.stringify(_arguments, getCircularReplacer());
+      NewRelicCapacitorPlugin.recordCustomEvent({
+        eventType: 'consoleEvents',
+        eventName: 'JSConsole',
+        attributes: { consoleType: consoleType, args: argsStr },
+      });
+    }
   });
 }
 


### PR DESCRIPTION
- Created API to get current state of agent configuration
- Created new `AgentConfiguration` interface with our agent configuration settings
- Created new configuration setting `sendConsoleEvents` to allow users to choose whether or not to send JS console events to New Relic