### PR TITLE
feat: Resolve JS errors as handled exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,15 +717,14 @@ Vue.config.errorHandler = (err, vm, info) => {
 
 ### How to see JSErrors(Fatal/Non Fatal) in NewRelic One?
 
-There is no section for JavaScript errors, but you can see JavaScript errors in custom events and also query them in NRQL explorer.
-
-<img width="1753" alt="Screen Shot 2022-02-10 at 12 41 11 PM" src="https://user-images.githubusercontent.com/89222514/153474861-87213e70-c3fb-4e14-aee7-a6a3fb482f73.png">
-
+JavaScript errors can be seen in the `Handled Exceptions` tab or as a `MobileHandledException` event. You can also see these errors in the NRQL explorer using this query:
 You can also build dashboard for errors using this query:
 
   ```sql
-  SELECT jsAppVersion,name,Message,errorStack,isFatal FROM `JS Errors` SINCE 24 hours ago
+  SELECT * FROM `MobileHandledException` SINCE 24 hours ago
   ```
+
+Note: Errors that do not produce a stack trace will not appear in the `Handled Exceptions` tab but will appear as a `MobileHandledException` event.
 
 ## Contribute
 

--- a/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorException.java
+++ b/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorException.java
@@ -1,0 +1,8 @@
+package com.newrelic.capacitor.plugin;
+
+public class NewRelicCapacitorException extends Exception {
+    public NewRelicCapacitorException(String message, StackTraceElement[] stackTraceElements) {
+        super(message);
+        setStackTrace(stackTraceElements);
+    }
+}

--- a/android/src/test/java/com/getcapacitor/NewRelicCapacitorPluginUnitTest.java
+++ b/android/src/test/java/com/getcapacitor/NewRelicCapacitorPluginUnitTest.java
@@ -425,8 +425,9 @@ public class NewRelicCapacitorPluginUnitTest {
         verify(callWithGoodParams, times(1)).resolve();
         verify(callWithGoodParams, times(0)).reject(Mockito.anyString());
 
-        verify(callWithNoParams, times(0)).resolve();
-        verify(callWithNoParams, times(1)).reject(Mockito.anyString());
+        // We don't reject but instead use "null" for null parameters since it will cause an infinite loop
+        verify(callWithNoParams, times(1)).resolve();
+        verify(callWithNoParams, times(0)).reject(Mockito.anyString());
     }
 
     @Test

--- a/android/src/test/java/com/getcapacitor/NewRelicCapacitorPluginUnitTest.java
+++ b/android/src/test/java/com/getcapacitor/NewRelicCapacitorPluginUnitTest.java
@@ -13,9 +13,12 @@ import static org.mockito.Mockito.when;
 import com.newrelic.capacitor.plugin.NewRelicCapacitorPluginPlugin;
 
 import org.json.JSONException;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import static org.junit.Assert.assertEquals;
+
+import java.util.Stack;
 
 
 public class NewRelicCapacitorPluginUnitTest {
@@ -363,11 +366,51 @@ public class NewRelicCapacitorPluginUnitTest {
     }
 
     @Test
+    public void testParseStackTrace() {
+        String validStackTrace = "URIError: URI malformed\n" +
+                "    at decodeURI (<anonymous>)\n" +
+                "    at onClick (http://localhost/static/js/main.c5c44c49.js:2:617162)\n" +
+                "    at l.onClick (http://localhost/static/js/main.c5c44c49.js:2:549166)\n" +
+                "    at Object.Ae (http://localhost/static/js/main.c5c44c49.js:2:104391)\n" +
+                "    at We (http://localhost/static/js/main.c5c44c49.js:2:104545)\n" +
+                "    at http://localhost/static/js/main.c5c44c49.js:2:124445\n" +
+                "    at jr (http://localhost/static/js/main.c5c44c49.js:2:124539)\n" +
+                "    at zr (http://localhost/static/js/main.c5c44c49.js:2:124954)\n" +
+                "    at http://localhost/static/js/main.c5c44c49.js:2:130396\n" +
+                "    at cc (http://localhost/static/js/main.c5c44c49.js:2:194065)";
+
+        StackTraceElement[] parsedStackTrace = plugin.parseStackTrace(validStackTrace);
+        // Should be 10 lines (does not include name and message of error)
+        Assert.assertEquals(10, parsedStackTrace.length);
+        for(StackTraceElement ste : parsedStackTrace) {
+            Assert.assertNotNull(ste.getClassName());
+            Assert.assertNotNull(ste.getFileName());
+            Assert.assertNotNull(ste.getMethodName());
+        }
+
+        String invalidStackTrace = "fakeStackHere\n" +
+                "random words\n" +
+                "testing";
+        StackTraceElement[] invalidParse = plugin.parseStackTrace(invalidStackTrace);
+        Assert.assertEquals(0, invalidParse.length);
+    }
+
+    @Test
     public void testRecordError() {
         PluginCall callWithGoodParams = mock(PluginCall.class);
-        when(callWithGoodParams.getString("name")).thenReturn("fakeErrName");
-        when(callWithGoodParams.getString("message")).thenReturn("fakeErrMsg");
-        when(callWithGoodParams.getString("stack")).thenReturn("fakeErrStack");
+        when(callWithGoodParams.getString("name")).thenReturn("URIError");
+        when(callWithGoodParams.getString("message")).thenReturn("URI malformed");
+        when(callWithGoodParams.getString("stack")).thenReturn("URIError: URI malformed\n" +
+                "    at decodeURI (<anonymous>)\n" +
+                "    at onClick (http://localhost/static/js/main.c5c44c49.js:2:617162)\n" +
+                "    at l.onClick (http://localhost/static/js/main.c5c44c49.js:2:549166)\n" +
+                "    at Object.Ae (http://localhost/static/js/main.c5c44c49.js:2:104391)\n" +
+                "    at We (http://localhost/static/js/main.c5c44c49.js:2:104545)\n" +
+                "    at http://localhost/static/js/main.c5c44c49.js:2:124445\n" +
+                "    at jr (http://localhost/static/js/main.c5c44c49.js:2:124539)\n" +
+                "    at zr (http://localhost/static/js/main.c5c44c49.js:2:124954)\n" +
+                "    at http://localhost/static/js/main.c5c44c49.js:2:130396\n" +
+                "    at cc (http://localhost/static/js/main.c5c44c49.js:2:194065)");
         when(callWithGoodParams.getBoolean("isFatal")).thenReturn(false);
 
         PluginCall callWithNoParams = mock(PluginCall.class);

--- a/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
+++ b/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
@@ -29,6 +29,13 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
         var sendConsoleEvents: Bool = true;
     }
     
+    private let jscRegex = try! NSRegularExpression(pattern: #"^\s*(?:([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$"#,
+                                                    options: .caseInsensitive)
+    private let geckoRegex = try! NSRegularExpression(pattern:#"^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$"#,
+                                                      options: .caseInsensitive)
+    private let nodeRegex = try! NSRegularExpression(pattern:#"^\s*at (?:((?:\[object object\])?[^\\/]+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$"#,
+                                                     options: .caseInsensitive)
+    
     public override func load() {
     }
 
@@ -362,31 +369,61 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
         call.resolve()
     }
     
-    @objc func recordError(_ call: CAPPluginCall) {
-        guard let name = call.getString("name"),
-              let message = call.getString("message"),
-              let isFatal = call.getBool("isFatal") else {
-            call.reject("Bad parameters given to recordError")
-            return
+    func parseStackTrace(stackString : String) -> NSMutableArray {
+        let lines = stackString.split(whereSeparator: \.isNewline)
+
+        let linesStr = lines.map { subString -> String in
+            return String(subString)
         }
+        let stackFramesArr : NSMutableArray = []
+        var stringRange : NSRange
         
-        var errStack = "No stack available"
-        
-        // Sometimes error stack does not get reported if past a certain length
-        if let stack = call.getString("stack") {
-            if stack.count > 3994 {
-                let endIndex = stack.index(stack.startIndex, offsetBy: 3994)
-                let substring = stack[..<endIndex]
-                errStack = String(substring)
+        for line in linesStr {
+            var result : [NSTextCheckingResult]
+            stringRange = NSRange(location: 0, length: line.utf16.count)
+            if (jscRegex.matches(in: line, range: stringRange).first != nil) {
+                result = jscRegex.matches(in: line, range: stringRange)
+            } else if (geckoRegex.matches(in: line, range: stringRange).first != nil) {
+                result = geckoRegex.matches(in: line, range: stringRange)
+            } else if (nodeRegex.matches(in: line, range: stringRange).first != nil) {
+                result = nodeRegex.matches(in: line, range: stringRange)
             } else {
-                errStack = stack
+                continue
             }
+            
+            let stackTraceElement : NSMutableDictionary = [:]
+            
+            // iOS agent will automatically add default values if these keys don't exist
+            if let methodSubstrRange = Range(result[0].range(at:1), in: line) {
+                stackTraceElement["method"] = String(line[methodSubstrRange])
+            }
+            if let fileSubstrRange = Range(result[0].range(at:3), in: line) {
+                stackTraceElement["file"] = String(line[fileSubstrRange])
+            }
+            if let lineSubstrRange = Range(result[0].range(at:4), in: line) {
+                stackTraceElement["line"] = Int(String(line[lineSubstrRange]))
+            }
+            stackFramesArr.add(stackTraceElement)
         }
         
-        let attributes: [String: Any] = ["Name" : name, "Message" : message, "isFatal" : isFatal, "errorStack" : errStack]
+        return stackFramesArr
+    }
+    
+    @objc func recordError(_ call: CAPPluginCall) {
+        let name = call.getString("name") ?? "null"
+        let message = call.getString("message") ?? "null"
+        let isFatal = call.getBool("isFatal") ?? false
         
-        NewRelic.recordBreadcrumb("JS Errors", attributes: attributes)
-        NewRelic.recordCustomEvent("JS Errors", attributes: attributes)
+        let stack = call.getString("stack") ?? ""
+        let stackFramesArr = parseStackTrace(stackString: stack)
+        let attributes : [String: Any] = [
+            "name" : name,
+            "reason": message,
+            "fatal": isFatal,
+            "stackTraceElements": stackFramesArr
+        ]
+        NewRelic.recordHandledException(withStackTrace: attributes)
+
         call.resolve()
     }
     

--- a/ios/PluginTests/NewRelicCapacitorPluginTests.swift
+++ b/ios/PluginTests/NewRelicCapacitorPluginTests.swift
@@ -628,13 +628,14 @@ class NewRelicCapacitorPluginTests: XCTestCase {
             return
         }
         
+        // Should not reject with null error (avoid infinite loop)
         guard let callWithNoParams = CAPPluginCall(callbackId: "recordError",
                                              options: [:],
                                              success: { (result, call) in
-            XCTFail("recordError should fail with no parameters")
+            XCTAssertNotNil(result);
         },
                                              error:{ (err) in
-            XCTAssertEqual(err!.message, "Bad parameters given to recordError")
+            XCTFail("Error shouldn't have been called since we do not reject null errors")
         }) else {
             XCTFail("Bad call in testRecordError")
             return

--- a/ios/PluginTests/NewRelicCapacitorPluginTests.swift
+++ b/ios/PluginTests/NewRelicCapacitorPluginTests.swift
@@ -596,12 +596,28 @@ class NewRelicCapacitorPluginTests: XCTestCase {
         NewRelicCapacitorPlugin.setMaxEventPoolSize(callWithNoParams)
     }
     
+    func testParseStackTrace() {
+        let stackFramesArr = NewRelicCapacitorPlugin.parseStackTrace(stackString: "decodeURI@[native code]\nonClick@capacitor://localhost/static/js/main.512e3679.js:2:616972\n@capacitor://localhost/static/js/main.512e3679.js:2:549141\nAe@capacitor://localhost/static/js/main.512e3679.js:2:104370\nWe@capacitor://localhost/static/js/main.512e3679.js:2:104524\n@capacitor://localhost/static/js/main.512e3679.js:2:124424\njr@capacitor://localhost/static/js/main.512e3679.js:2:124513\nzr@capacitor://localhost/static/js/main.512e3679.js:2:124930\n@capacitor://localhost/static/js/main.512e3679.js:2:130372\ncc@capacitor://localhost/static/js/main.512e3679.js:2:194040\nRe@capacitor://localhost/static/js/main.512e3679.js:2:103499\nBr@capacitor://localhost/static/js/main.512e3679.js:2:126224\nUt@capacitor://localhost/static/js/main.512e3679.js:2:110620\nFt@capacitor://localhost/static/js/main.512e3679.js:2:110404\nFt@[native code]")
+        XCTAssertTrue((stackFramesArr as Any) is NSMutableArray)
+        XCTAssertEqual(15, stackFramesArr.count)
+        for stackFrame in stackFramesArr {
+            XCTAssertTrue((stackFrame as Any) is NSMutableDictionary)
+            let stackFrameDict = stackFrame as! NSMutableDictionary
+            XCTAssertNotNil(stackFrameDict["file"])
+            XCTAssertNotNil(stackFrameDict["method"])
+        }
+        
+        let badStackFrame = NewRelicCapacitorPlugin.parseStackTrace(stackString: "fakestacktrace\n poor structure\n testing")
+        XCTAssertTrue((badStackFrame as Any) is NSMutableArray)
+        XCTAssertEqual(0, badStackFrame.count)
+    }
+    
     func testRecordError() {
         guard let callWithGoodParams = CAPPluginCall(callbackId: "recordError",
-                                               options: ["name": "fakeError",
-                                                         "message": "fakeMsg",
-                                                         "stack": "fakeStack",
-                                                         "isFatal": false],
+                                               options: ["name": "URIError",
+                                                         "message": "URI error",
+                                                         "stack": "decodeURI@[native code]\nonClick@capacitor://localhost/static/js/main.512e3679.js:2:616972\n@capacitor://localhost/static/js/main.512e3679.js:2:549141\nAe@capacitor://localhost/static/js/main.512e3679.js:2:104370\nWe@capacitor://localhost/static/js/main.512e3679.js:2:104524\n@capacitor://localhost/static/js/main.512e3679.js:2:124424\njr@capacitor://localhost/static/js/main.512e3679.js:2:124513\nzr@capacitor://localhost/static/js/main.512e3679.js:2:124930\n@capacitor://localhost/static/js/main.512e3679.js:2:130372\ncc@capacitor://localhost/static/js/main.512e3679.js:2:194040\nRe@capacitor://localhost/static/js/main.512e3679.js:2:103499\nBr@capacitor://localhost/static/js/main.512e3679.js:2:126224\nUt@capacitor://localhost/static/js/main.512e3679.js:2:110620\nFt@capacitor://localhost/static/js/main.512e3679.js:2:110404\nFt@[native code]",
+                                                         "isFatal": true],
                                                success: { (result, call) in
             XCTAssertNotNil(result)
         },


### PR DESCRIPTION
Use regex to parse stack frames and pass the JS/TS error as a native handled exception. 