### PR TITLE
fix: support non-text xhr response types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,12 +95,13 @@ type NetworkRequest = {
   endTime?: number;
   status?: number;
   bytesreceived?: number;
-  body?: string;
+  body: string;
 };
 
 const networkRequest: NetworkRequest = {
   url: "",
   method: "",
+  body: "",
   bytesSent: 0,
   startTime: 0,
 };
@@ -142,13 +143,18 @@ window.XMLHttpRequest.prototype.send = function (
         if (this.readyState === this.DONE) {
           networkRequest.endTime = Date.now();
           networkRequest.status = this.status;
-          
-          if (this.responseText !== undefined) {
+
+          const type = this.responseType;
+          if (type === "arraybuffer") {
+            networkRequest.bytesreceived = this.response.byteLength as number;
+          } else if (type === "blob") {
+            networkRequest.bytesreceived = this.response.size as number;
+          } else if (type === "text" || type === "" || type === undefined) {
             networkRequest.bytesreceived = this.responseText.length;
             networkRequest.body = this.responseText;
           } else {
+            // unsupported response type
             networkRequest.bytesreceived = 0;
-            networkRequest.body = "";
           }
 
           NewRelicCapacitorPlugin.noticeHttpTransaction({


### PR DESCRIPTION
The HTTP Instrumentation for XMLHttpRequest added in version [1.3.1](https://github.com/newrelic/newrelic-capacitor-plugin/releases/tag/1.3.1) doesn't play nice with non-text response types.
e.g. When using this library with cognito an error is observed: 
> `“Failed to read the ‘responseText’ property from ‘XMLHttpRequest’: The value is only accessible if the object’s ‘responseType’ is ‘’ or ‘text’ (was ‘arraybuffer’).`

This adds support for `blob` and `arraybuffer` responses, but also should prevent errors from other types of responses that aren't explicitly supported. Any unsupported response type will just report 0 bytes received. 