### PR TITLE
Fix build/unit tests failures and warnings, and update to Xcode 15.3 (issue 79)

### DIFF
--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -190,8 +190,9 @@
 		50ADFF7F201F53D600D50D53 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1530;
 				ORGANIZATIONNAME = "Max Lynch";
 				TargetAttributes = {
 					50ADFF87201F53D600D50D53 = {
@@ -453,7 +454,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -474,7 +476,12 @@
 				INFOPLIST_FILE = Plugin/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)\n$(FRAMEWORK_SEARCH_PATHS)\n$(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)\n$(FRAMEWORK_SEARCH_PATHS)\n$(FRAMEWORK_SEARCH_PATHS)",
+				);
 				NEW_SETTING = "";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.getcapacitor.Plugin;
@@ -501,7 +508,12 @@
 				INFOPLIST_FILE = Plugin/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
 				NEW_SETTING = "";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.getcapacitor.Plugin;
@@ -519,7 +531,11 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = PluginTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.getcapacitor.PluginTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -533,7 +549,11 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = PluginTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.getcapacitor.PluginTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/ios/Plugin.xcodeproj/xcshareddata/xcschemes/Plugin.xcscheme
+++ b/ios/Plugin.xcodeproj/xcshareddata/xcschemes/Plugin.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Plugin.xcodeproj/xcshareddata/xcschemes/PluginTests.xcscheme
+++ b/ios/Plugin.xcodeproj/xcshareddata/xcschemes/PluginTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
+++ b/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
@@ -585,7 +585,7 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
             return ;
         }
         
-        let headersDict = NewRelic.addHTTPHeaderTracking(for: headers)
+        NewRelic.addHTTPHeaderTracking(for: headers)
     }
     
     @objc func getHTTPHeadersTrackingFor(_ call: CAPPluginCall) {

--- a/ios/PluginTests/NewRelicCapacitorPluginTests.swift
+++ b/ios/PluginTests/NewRelicCapacitorPluginTests.swift
@@ -449,15 +449,15 @@ class NewRelicCapacitorPluginTests: XCTestCase {
                                                          "endTime": Date().timeIntervalSince1970,
                                                          "failure": "BadURL"],
                                                success: { (result, call) in
-            XCTAssertNotNil(result)
+            XCTFail("noticeHttpTransaction should not work with bad params")
         },
                                                error:{ (err) in
-            XCTFail("Error shouldn't have been called")
+            XCTAssertNotNil(err)
+            XCTAssertEqual(err!.message, "Bad parameters given to noticeHttpTransaction")
         }) else {
             XCTFail("Bad call in noticeNetworkFailure")
             return
         }
-        
 
         guard let callWithNoParams = CAPPluginCall(callbackId: "noticeNetworkFailure",
                                              options: [:],

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,11 +9,11 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'NewRelicAgent', '7.4.8'
+  pod 'NewRelicAgent', '7.4.10'
 end
 
 target 'PluginTests' do
   capacitor_pods
-  pod 'NewRelicAgent', '7.4.8'
+  pod 'NewRelicAgent', '7.4.10'
 end
 


### PR DESCRIPTION
This PR addresses issue https://github.com/newrelic/newrelic-capacitor-plugin/issues/79

It includes 3 commits:

1. fix warnings related to usage of `NewRelic.addHTTPHeaderTracking`.
2. Fix build, including a unit test expecting a success for a badly configured `CAPPluginCall`.
3. Minor project fixes for using Xcode 15.3. These are changes suggested by Xcode that do not impact the build.