### PR TITLE
fix: ios agent is unable to start if backgroudnreporting flag is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.2
+
+- Disabled the background reporting functionality to resolve an issue on the iOS side.
+
+
 ## 1.4.1
 
 * Improvements

--- a/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
+++ b/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
@@ -28,9 +28,9 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
         var crashCollectorAddress: String = "mobile-crash.newrelic.com"
         var sendConsoleEvents: Bool = true;
         var fedRampEnabled: Bool = false;
-        var offlineStorageEnabled = true;
-        var backgroundReportingEnabled = false;
-        var newEventSystemEnabled = true;
+        var offlineStorageEnabled: Bool = true;
+        var backgroundReportingEnabled: Bool = false;
+        var newEventSystemEnabled: Bool = true;
 
     }
     
@@ -112,12 +112,12 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin {
                agentConfig.newEventSystemEnabled = true;
            }
             
-            if agentConfiguration["offlineStorageEnabled"] as? Bool == false {
+            if agentConfiguration["backgroundReportingEnabled"] as? Bool == true {
+                  NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting)
+               agentConfig.backgroundReportingEnabled = true;
+           } else {
                NewRelic.disableFeatures(NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting)
                agentConfig.backgroundReportingEnabled = false;
-           } else {
-               NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting)
-               agentConfig.backgroundReportingEnabled = true;
            }
 
             if agentConfiguration["fedRampEnabled"] as? Bool == true {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/newrelic-capacitor-plugin",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "NewRelic Plugin for ionic Capacitor",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
#91