### PR TITLE
disable the Distributed tracing for Web Plugin

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -99,7 +99,7 @@ export class NewRelicCapacitorPluginWeb extends WebPlugin implements NewRelicCap
             sendConsoleEvents: true,
             fedRampEnabled: false,
             offlineStorageEnabled:true,
-            distributedTracingEnabled:true,
+            distributedTracingEnabled:false,
         };
        return new Promise((resolve) => {
             resolve(a);


### PR DESCRIPTION
this web plugin is only for testing on browser , it is only for testing. #109 