### PR TITLE
Always respect logLevel config

### DIFF
--- a/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorPluginPlugin.java
+++ b/android/src/main/java/com/newrelic/capacitor/plugin/NewRelicCapacitorPluginPlugin.java
@@ -249,6 +249,7 @@ public class NewRelicCapacitorPluginPlugin extends Plugin {
             NewRelic.withApplicationToken(appKey)
                     .withApplicationFramework(ApplicationFramework.Capacitor, "1.5.8")
                     .withLoggingEnabled(loggingEnabled)
+                    .withLogLevel(logLevel)
                     .start(this.getActivity().getApplication());
         } else {
             if(collectorAddress == null) {


### PR DESCRIPTION
decouple logLevel from collectorAddress and crashCollectorAddress in NewRelic builder