### PR TITLE
fix invalid traceattribute values causing parsing error on null NSString

### DIFF
--- a/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
+++ b/ios/Plugin/NewRelicCapacitorPluginPlugin.swift
@@ -357,7 +357,7 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin, CAPBridgedPlugin {
     }
     
     
-    @objc func noticeHttpTransaction(_ call: CAPPluginCall) {
+        @objc func noticeHttpTransaction(_ call: CAPPluginCall) {
         guard let url = call.getString("url"),
               let method = call.getString("method"),
               let status = call.getInt("status"),
@@ -378,7 +378,27 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin, CAPBridgedPlugin {
         let uint_bytesReceived = UInt(bytesReceived)
         let data = Data(body.utf8)
         let traceAttributes = call.getObject("traceAttributes")
+        
+        
+        var sanitizedTraceHeaders: [String: String]? = nil
 
+        if let dict = traceAttributes as? [String: Any] {
+            var out: [String: String] = [:]
+            out.reserveCapacity(dict.count)
+
+            for (key, value) in dict {
+                if value is NSNull {
+                    out[key] = ""
+                } else if let s = value as? String {
+                    out[key] = s
+                } else {
+                    out[key] = ""
+                }
+            }
+
+            sanitizedTraceHeaders = out.isEmpty ? nil : out
+        }
+        
         NewRelic.noticeNetworkRequest(
             for: nsurl,
             httpMethod: method,
@@ -389,7 +409,7 @@ public class NewRelicCapacitorPluginPlugin: CAPPlugin, CAPBridgedPlugin {
             bytesSent: uint_bytesSent,
             bytesReceived: uint_bytesReceived,
             responseData: data,
-            traceHeaders: traceAttributes,
+            traceHeaders: sanitizedTraceHeaders,
             andParams: nil
         )
         call.resolve()


### PR DESCRIPTION
App crashes cause of parsing error on null. 

-[NSNull componentsSeparatedByString:]: unrecognized selector sent to instance.
NewRelic: +[NRMANetworkFacade configureNRMAPayloadWithTraceHeaders:traceHeaders:] 

The values in the traceArguments are all null. This also only happened if a status code >= 400 occurs which runs in the problematic path where the null values are beeing cast as a utf8 string.