### PR TITLE
Fix not updated package version in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/newrelic/newrelic-ios-agent-spm.git", from: "7.6.0")
+        .package(url: "https://github.com/newrelic/newrelic-ios-agent-spm.git", from: "7.6.3")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
This PR updates the Swift Package Manager dependency version in `Package.swift` from `7.6.0` to `7.6.3`.

## Why
The repository already references iOS agent version `7.6.3` in other places, but `Package.swift` still points to `7.6.0`. This creates an inconsistency for users integrating the plugin through Swift Package Manager.

## Change
- Update `newrelic-ios-agent-spm` in `Package.swift`
- Change version from `7.6.0` to `7.6.3`

## Impact
This keeps the SPM configuration aligned with the currently expected iOS agent version and avoids confusion or mismatched dependency resolution for SPM users.
