### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - '.eslint*'
 name: iOS Unit Tests
+permissions:
+  contents: read
 jobs:
   ios:
     name: iOS Unit Tests


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/9](https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/9)

Add an explicit top-level `permissions` block in `.github/workflows/ios.yml` so all jobs in this workflow inherit least-privilege token access.  
Best fix here (without changing functionality): add:

```yaml
permissions:
  contents: read
```

Place it at the workflow root (e.g., after `name:` and before `jobs:`). This is sufficient for `actions/checkout` and test/build steps that only read repository contents. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
