### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/6](https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/6)

Add an explicit `permissions` block in `.github/workflows/repolinter.yml` at the workflow root (just below `on:`) so it applies to all jobs unless overridden.  
For this workflow, the best least-privilege baseline is:

- `contents: read` (needed for checkout/repo read operations)
- `issues: write` (needed because repolinter is configured with `output_type: issue`)

This preserves existing behavior while restricting token access versus implicit defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
