### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - '.eslint*'
 name: Verify build
+permissions:
+  contents: read
 jobs:
   build:
     name: Verify build


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/4](https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/4)

To fix this, add an explicit `permissions` block to the workflow with the least privilege required. Since this workflow only checks out code and runs local build/verify commands, the minimal needed permission is `contents: read`.

Best single fix (without changing functionality): in `.github/workflows/build.yml`, add a root-level `permissions` key immediately after `name` (or before `jobs`) so it applies to all jobs in the workflow. Use:

```yaml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
