### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,8 @@ on:
       - 'LICENSE'
       - '.eslint*'
 name: Android Unit Tests
+permissions:
+  contents: read
 jobs:
   android:
     name: Android Unit Tests


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/3](https://github.com/newrelic/newrelic-capacitor-plugin/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/android.yml` at the workflow root (top-level, alongside `on`, `name`, `jobs`) so all jobs inherit minimal token scope. For this CI workflow, `contents: read` is the best minimal permission and should preserve existing behavior (checkout/read-only operations). No new imports, methods, or dependencies are needed; only YAML workflow configuration is updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
